### PR TITLE
fix: replace distracting background with blurred CSS pseudo-element

### DIFF
--- a/product.css
+++ b/product.css
@@ -10,6 +10,16 @@ body {
     color: #333;
 }
 
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: url('https://images.unsplash.com/photo-1600891964599-f61ba0e24092?auto=format&fit=crop&w=1350&q=80') no-repeat center center;
+  filter: blur(5px) brightness(0.85);
+  z-index: -1;
+  transform: scale(1.05);
+}
+
 /* NAVBAR */
 .navbar {
     display: flex;

--- a/style.css
+++ b/style.css
@@ -10,6 +10,16 @@ body {
   background-size: cover;
 }
 
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: url('https://images.unsplash.com/photo-1600891964599-f61ba0e24092?auto=format&fit=crop&w=1350&q=80') no-repeat center center;
+  filter: blur(5px) brightness(0.85);
+  z-index: -1;
+  transform: scale(1.05);
+}
+
 /* ================= NAVBAR ================= */
 
 .navbar {


### PR DESCRIPTION
## 📌 Description
Replaces the visually distracting background image with a blurred version using CSS `filter: blur()` on a pseudo-element, improving readability without removing the background entirely.
---

## 🔗 Related Issue
Closes: #21 
---

## 🛠 Changes Made
- Added `body::before` pseudo-element with `filter: blur(6px)` for a softened background
- Added `transform: scale(1.05)` to prevent white edges caused by blur
---

## 📷 Screenshots (if applicable)
**Before:**
<img width="1879" height="999" alt="image" src="https://github.com/user-attachments/assets/ac305abd-6a6e-4179-b43f-eaa74ea751a0" />

**After:**
<img width="1878" height="995" alt="image" src="https://github.com/user-attachments/assets/6ffe4210-59fe-4478-ae43-887330241302" />
---

## ✅ Checklist
- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue
